### PR TITLE
commit basic code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libdeflate"]
+	path = libdeflate
+	url = https://github.com/ebiggers/libdeflate

--- a/fastq_calculator.h
+++ b/fastq_calculator.h
@@ -1,0 +1,154 @@
+#ifndef FASTQSTAT_CALC_H_
+#define FASTQSTAT_CALC_H_
+
+#include <atomic>
+#include <fstream>
+#include <immintrin.h>
+#include <iostream>
+#include <string.h>
+#include <thread>
+#include <vector>
+struct Stat {
+    long linenum = 0;
+    long yield = 0;
+    long q20_base = 0;
+    long q30_base = 0;
+};
+
+class FastqCalculator {
+  public:
+    FastqCalculator() {}
+    ~FastqCalculator() {
+        if (buffer != nullptr) {
+            delete[] buffer;
+        }
+    }
+    bool Calculate(const char *buffer, long buffer_size, int thread_count,
+                   Stat &stat_file);
+    void Free() {
+        if (buffer != nullptr) {
+            delete[] buffer;
+            buffer = nullptr;
+        }
+    }
+    char *buffer = nullptr;
+};
+
+void correct_pos(const char *buffer, long *const cur_end_pos,
+                 long *const next_start_pos) {
+    while (buffer[*next_start_pos] != '@') {
+        (*next_start_pos)++;
+    }
+    *cur_end_pos = *next_start_pos;
+}
+
+void find_qc_pos_job(const char *buffer, long start_pos, long end_pos,
+                     Stat &stat) {
+
+    // avx-512 code, seq라인을 읽어서 score line의 length를 읽어들이고, 그 길이만큼 simd명령을 수행한다.
+    int line_index =0;
+    __m512i q20 = _mm512_set1_epi8(20 + 33);
+    __m512i q30 = _mm512_set1_epi8(30 + 33);
+    char score_line[64*4];
+    int yield =0;
+
+    for(long i = start_pos; i < end_pos; i++) {
+        char c = buffer[i];
+        if(c == '@') {
+            line_index = 0;
+            stat.linenum++;
+            yield = 0;
+            memset(score_line, 0, sizeof(score_line));
+        }
+        if(c == '\n') {
+            line_index++;
+            continue;
+        } else if(c != 0) {
+            if(line_index == 1){
+                yield++;
+            } 
+            if (line_index == 3) {
+                memcpy(score_line, buffer + i, yield);
+                int yield_64_count = (yield + 63) / 64;
+                for(int j = 0; j < yield_64_count; j++) {
+                    __m512i score = _mm512_loadu_epi8(score_line + j*64);
+                    __mmask64 q20_mask = _mm512_cmpge_epi8_mask(score, q20);
+                    __mmask64 q30_mask = _mm512_cmpge_epi8_mask(score, q30);
+                    stat.q20_base += _mm_popcnt_u64(q20_mask);
+                    stat.q30_base += _mm_popcnt_u64(q30_mask);
+                }
+                stat.yield += yield;
+                i += yield;
+            }
+        }
+    }
+    /* 기존 한 글자씩 읽는 코드..
+    int line_index = 0;
+    for (long i = start_pos; i < end_pos; i++) {
+        char c = buffer[i];
+        if (c == '@') {
+            line_index = 0;
+            stat.linenum++;
+        }
+
+        if (c == '\n') {
+            if (line_index == 3) {
+            }
+            line_index++;
+            continue;
+        } else if (c != 0) {
+            if (line_index == 3) {
+                stat.yield++;
+                if (c - 33 >= 20) {
+                    stat.q20_base++;
+                }
+                if (c - 33 >= 30) {
+                    stat.q30_base++;
+                }
+            }
+        }
+    }
+    */
+}
+
+bool FastqCalculator::Calculate(const char *buffer, long buffer_size,
+                                int thread_count, Stat &stat_file) {
+    long *thread_start_pos = new long[thread_count];
+    long *thread_end_pos = new long[thread_count];
+    long basic_step = buffer_size / thread_count;
+    for (int i = 0; i < thread_count; i++) {
+        thread_start_pos[i] = i * basic_step;
+        thread_end_pos[i] =
+            (i == thread_count - 1) ? buffer_size : (i + 1) * basic_step;
+    }
+
+    // Correct start and end position
+    for (int i = 0; i < thread_count - 1; i++) {
+        long before_start_pos = thread_start_pos[i];
+        long before_end_pos = thread_end_pos[i];
+        correct_pos(buffer, &thread_end_pos[i], &thread_start_pos[i + 1]);
+    }
+
+    // Extract QC data from buffer in parallel
+    std::thread *threads = new std::thread[thread_count];
+    Stat *stat = new Stat[thread_count];
+    for (int i = 0; i < thread_count; i++) {
+        threads[i] = std::thread(find_qc_pos_job, buffer, thread_start_pos[i],
+                                 thread_end_pos[i], std::ref(stat[i]));
+    }
+    for (int i = 0; i < thread_count; i++) {
+        threads[i].join();
+
+        stat_file.linenum += stat[i].linenum;
+        stat_file.yield += stat[i].yield;
+        stat_file.q20_base += stat[i].q20_base;
+        stat_file.q30_base += stat[i].q30_base;
+    }
+
+    delete[] thread_start_pos;
+    delete[] thread_end_pos;
+    delete[] threads;
+
+    return true;
+}
+#endif // FASTQSTAT_CALC_H_

--- a/fastq_loader.h
+++ b/fastq_loader.h
@@ -1,0 +1,79 @@
+#ifndef FASTQSTAT_LOADER_H_
+#define FASTQSTAT_LOADER_H_
+#include "fastq_unzip.h"
+/**
+ * @class FastqLoader
+ * @brief A class to load and process FASTQ files.
+ *
+ * The FastqLoader class provides functionality to load FASTQ files
+ * and manage the associated resources.
+ */
+class FastqLoader {
+  public:
+    FastqLoader() {};
+    ~FastqLoader() {
+        if (decomper != nullptr) {
+            delete decomper;
+        }
+        if (buffer != nullptr) {
+            delete[] buffer;
+        }
+    };
+    bool Load(const std::string &file_name, int thread_count);
+    char *buffer = nullptr;
+    long buffer_size = 0;
+
+  private:
+    FastqUnzip *decomper = nullptr;
+};
+
+/**
+ * @brief Loads a FASTQ file, either compressed (.gz) or uncompressed.
+ *
+ * This function attempts to load a FASTQ file specified by the file_name parameter.
+ * If the file is compressed (with a .gz extension), it will be decompressed using
+ * the FastqUnzip class. If the file is uncompressed, it will be read directly.
+ *
+ * @param file_name The name of the FASTQ file to load.
+ * @param thread_count The number of threads to use for decompression (if applicable).
+ * @return true if the file was successfully loaded, false otherwise.
+ */
+bool FastqLoader::Load(const std::string &file_name, int thread_count) {
+    std::ifstream file;
+
+    if (file_name.find(".gz") != std::string::npos) {
+        decomper = new FastqUnzip();
+        if (!decomper->Unzip(file_name, thread_count)) {
+            std::cerr << "Failed to decompress file: " << file_name
+                      << std::endl;
+            return false;
+        }
+        buffer = decomper->uncompressed_buffer;
+        buffer_size = decomper->total_out_size;
+    } else {
+        file.open(file_name);
+        if (!file.is_open()) {
+            std::cerr << "Failed to open file: " << file_name << std::endl;
+            return false;
+        }
+
+        // Get file size
+        file.seekg(0, std::ios::end);
+        buffer_size = file.tellg();
+        file.seekg(0, std::ios::beg);
+
+        // Allocate buffer
+        buffer = new char[buffer_size];
+        if (buffer == nullptr) {
+            std::cerr << "Failed to allocate buffer" << std::endl;
+            return false;
+        }
+        // Read file
+        file.read(buffer, buffer_size);
+        file.close();
+    }
+    //std::cout << "load finish. file_name : " << file_name
+    //          << ", load_size : " << buffer_size << std::endl;
+    return true;
+}
+#endif // FASTQSTAT_LOADER_H_

--- a/fastq_stat.cpp
+++ b/fastq_stat.cpp
@@ -1,0 +1,63 @@
+#include "fastq_calculator.h"
+#include "fastq_loader.h"
+#include <atomic>
+#include <iostream>
+#include <thread>
+
+
+void thread_job(FastqLoader &loader, const std::string &file_name,
+                int thread_count, Stat &stat_file) {
+    if (loader.Load(file_name, thread_count) == false) {
+        std::cerr << "Failed to load file: " << file_name << std::endl;
+        return;
+    }
+    FastqCalculator calculator;
+
+    if (calculator.Calculate(loader.buffer, loader.buffer_size,
+                                thread_count, stat_file)) {
+        calculator.Free();
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 4) {
+        std::cout << "Usage: " << argv[0]
+                  << " <fastq_file1> <fastq_file2> <thread_count>" << std::endl;
+        return -1;
+    }
+    const int file_count = 2;
+    std::string file_name[file_count];
+    std::string thread_count_str(argv[3]);
+    int thread_count = std::stoi(thread_count_str);
+    int thread_count_per_file = (thread_count + 0.5) / file_count;
+    std::thread *threads[file_count];
+    FastqLoader loader[file_count];
+    Stat stat_file[file_count];
+    Stat stat_total;
+
+    for(int i = 0; i<file_count; i++)
+    {
+        file_name[i] = std::string(argv[i + 1]);
+        threads[i] = new std::thread(thread_job, std::ref(loader[i]), file_name[i], thread_count_per_file, std::ref(stat_file[i]));
+    }
+    for (int i = 0; i < file_count; i++) {
+        threads[i]->join();
+        stat_total.linenum += stat_file[i].linenum;
+        stat_total.yield += stat_file[i].yield;
+        stat_total.q20_base += stat_file[i].q20_base;
+        stat_total.q30_base += stat_file[i].q30_base;
+    }
+
+    double read_length = (double)stat_total.yield / (double)stat_total.linenum;
+    double Q20 = (double)stat_total.q20_base / (double)stat_total.yield * 100;
+    double Q30 = (double)stat_total.q30_base / (double)stat_total.yield * 100;
+    std::cout << "{\n";
+    std::cout << "  \"Total Yield\": " << stat_total.yield << ",\n";
+    std::cout << "  \"Total reads\": " << stat_total.linenum << ",\n";
+    std::cout << "  \"Average read length\": " << read_length << ",\n";
+    std::cout << "  \"Q20(%)\": " << Q20 << ",\n";
+    std::cout << "  \"Q30(%)\": " << Q30 << "\n";
+    std::cout << "}" << std::endl;
+
+    return 0;
+}

--- a/fastq_unzip.h
+++ b/fastq_unzip.h
@@ -1,0 +1,454 @@
+#ifndef FASTQSTAT_UNZIP_H_
+#define FASTQSTAT_UNZIP_H_
+#include "./libdeflate/libdeflate.h"
+#include <algorithm>
+#include <atomic>
+#include <fstream>
+#include <iostream>
+#include <pthread.h>
+#include <string.h>
+#include <vector>
+#include <immintrin.h>
+
+typedef struct gzip_block {
+    long index = 0;
+    long offset = 0;
+    long compressed_size = 0;
+    long uncompressed_size = 0;
+    char *compressed = 0;
+    char *uncompressed = 0;
+    long actual_out_nbytes = 0;
+} GZIP_BLOCK;
+
+typedef struct {
+    const unsigned char *buffer;
+    long start;
+    long length;
+    std::vector<long> offsets;
+} OFFSET_THREAD_PARAM;
+
+typedef struct {
+    long start;
+    long length;
+    std::vector<GZIP_BLOCK> *blocks;
+    std::atomic<long> *total_size;
+} THREAD_PARAM;
+
+typedef struct {
+    std::vector<GZIP_BLOCK> *blocks;
+    char *buffer;
+    long start;
+    long end;
+} MERGE_THREAD_PARAM;
+
+/**
+ * @class FastqUnzip
+ * @brief A class to handle the unzipping of FASTQ files.
+ * 
+ * This class provides functionality to unzip FASTQ files using a specified number of threads.
+ * It maintains an uncompressed buffer and tracks the total output size.
+ */
+class FastqUnzip {
+  public:
+    FastqUnzip() { total_out_size = 0; };
+    ~FastqUnzip() {}
+    bool Unzip(const std::string &file_name, int thread_count);
+    char *uncompressed_buffer = nullptr;
+    std::atomic<long> total_out_size;
+};
+
+/**
+ * @brief Thread function to find specific patterns in a buffer and store their offsets.
+ *
+ * This function searches through a buffer for a specific pattern of bytes that 
+ * indicate the start of a compressed block (gzip header). When such a pattern 
+ * is found, the offset (position) of the pattern in the buffer is stored in 
+ * the offsets vector of the parameter structure.
+ *
+ * @param arg A pointer to an OFFSET_THREAD_PARAM structure containing the 
+ *        buffer to search, the start position, the length of the segment to 
+ *        search, and the vector to store the offsets.
+ * @return Always returns (void *)1.
+ */
+void *offset_thread(void *arg) {
+    OFFSET_THREAD_PARAM *param = (OFFSET_THREAD_PARAM *)arg;
+    long i = 0;
+    for (i = param->start; i < param->start + param->length; ++i) {
+        if (param->buffer[i] == 0x1f && param->buffer[i + 1] == 0x8b &&
+            param->buffer[i + 2] == 0x08) {
+            if ((param->buffer[i + 3] & 0xE0) ==
+                0x0) { /// flags. The most significant 3 bits are reserved for
+                       /// 0s.
+                if (param->buffer[i + 8] == 0x0 ||
+                    param->buffer[i + 8] == 0x2 ||
+                    param->buffer[i + 8] ==
+                        0x4) { /// extra flags. Only 2 and 4 are valid for
+                               /// deflate method (CM=8).
+                    if (param->buffer[i + 9] == 0x0 ||
+                        param->buffer[i + 9] == 0x3 ||
+                        param->buffer[i + 9] == 255) { /// OS.
+                        param->offsets.push_back(i);
+                    }
+                }
+            }
+        }
+    }
+
+    return (void *)1;
+}
+
+/**
+ * @brief Finds and processes gzip members in a given buffer.
+ *
+ * This function divides the buffer into chunks and processes each chunk in a separate thread
+ * to find gzip members. The offsets of the gzip members are collected and used to create
+ * GZIP_BLOCK structures which are stored in the destination vector.
+ *
+ * @param buffer Pointer to the buffer containing the gzip data.
+ * @param file_size Size of the buffer.
+ * @param core Number of threads to use for processing.
+ * @param dest Pointer to a vector where the found GZIP_BLOCK structures will be stored.
+ * @return true if gzip members are found and processed successfully, false otherwise.
+ */
+bool find_gzip_members(const char *const buffer, const long &file_size,
+                       const int &core, std::vector<GZIP_BLOCK> *const dest) {
+
+    long chunk_size = file_size / core;
+    long start = 0;
+    int i = 0;
+    std::vector<OFFSET_THREAD_PARAM *> params;
+    std::vector<pthread_t> threads;
+    for (i = 0, start = 0; i < core; ++i, start += chunk_size) {
+        OFFSET_THREAD_PARAM *p = new OFFSET_THREAD_PARAM;
+        p->start = start - 10; /// 3-byte overlap. +7 for more sure.
+        if (p->start + chunk_size >= file_size) {
+            p->length = file_size - p->start;
+        } else {
+            p->length = chunk_size;
+        }
+        p->buffer = (const unsigned char *)buffer;
+
+        pthread_t t;
+        int s = pthread_create(&t, NULL, offset_thread, (void *)p);
+        if (s != 0) {
+            delete p;
+        }
+        params.push_back(p);
+        threads.push_back(t);
+    }
+
+    std::vector<pthread_t>::iterator thread;
+    for (thread = threads.begin(); thread != threads.end(); ++thread) {
+        void *res = NULL;
+        pthread_join(*thread, &res);
+    }
+
+    std::vector<long> offsets;
+    std::vector<OFFSET_THREAD_PARAM *>::iterator param;
+    for (param = params.begin(); param != params.end(); ++param) {
+        if ((*param)->offsets.empty() == true) {
+            delete (*param);
+            continue;
+        }
+        offsets.insert(offsets.begin(), (*param)->offsets.begin(),
+                       (*param)->offsets.end());
+
+        delete (*param);
+    }
+    params.clear();
+
+    //std::cout << "total number of members:" << offsets.size() << std::endl;
+
+    if (offsets.empty() == true) {
+        std::cerr << "No offsets found." << std::endl;
+        return false;
+    }
+
+    if (offsets.size() == 1) {
+        long length = file_size - offsets[0];
+        unsigned int isize = *(unsigned int *)(buffer + file_size - 4);
+
+        GZIP_BLOCK block;
+        block.index = 0;
+        block.offset = offsets[0];
+        block.compressed_size = length;
+        block.uncompressed_size = isize;
+        block.compressed = (char *)(buffer + block.offset);
+        block.uncompressed = NULL;
+        dest->push_back(block);
+
+        return true;
+    }
+
+    std::sort(offsets.begin(), offsets.end());
+    long index = 0;
+    std::vector<long>::const_iterator offset;
+    std::vector<long>::const_iterator next_offset;
+    for (offset = offsets.begin(), next_offset = offsets.begin() + 1, index = 0;
+         next_offset != offsets.end(); ++offset, ++next_offset, ++index) {
+        if (*offset == *next_offset)
+            continue;
+
+        long length = *next_offset - *offset + 1;
+        unsigned int isize = *(unsigned int *)(buffer + *next_offset - 4);
+
+        GZIP_BLOCK block;
+        block.index = index;
+        block.offset = *offset;
+        block.compressed_size = length;
+        block.uncompressed_size = isize;
+        block.compressed = (char *)(buffer + block.offset);
+        block.uncompressed = NULL;
+        dest->push_back(block);
+    }
+
+    /// Process last member.
+    long last_offset = offsets.back();
+    if (last_offset != dest->back().offset) {
+        long length = file_size - last_offset;
+        unsigned int isize = *(unsigned int *)(buffer + file_size - 4);
+
+        GZIP_BLOCK block;
+        block.index = index;
+        block.offset = last_offset;
+        block.compressed_size = length;
+        block.uncompressed_size = isize;
+        block.compressed = (char *)(buffer + block.offset);
+        block.uncompressed = NULL;
+        dest->push_back(block);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Thread function to decompress GZIP blocks.
+ *
+ * This function is executed by a thread to decompress a range of GZIP blocks
+ * specified by the THREAD_PARAM argument. It allocates a decompressor, iterates
+ * over the specified blocks, and decompresses each block. If the decompressed
+ * size is insufficient, it reallocates the buffer with double the size and
+ * retries decompression. The total decompressed size is accumulated in the
+ * THREAD_PARAM structure.
+ *
+ * @param arg Pointer to a THREAD_PARAM structure containing the parameters for
+ *            the thread, including the range of blocks to decompress and a
+ *            pointer to the total size accumulator.
+ * @return Always returns (void *)1.
+ */
+void *job_thread(void *arg) {
+    THREAD_PARAM param = *(THREAD_PARAM *)arg;
+    delete (THREAD_PARAM *)arg;
+    libdeflate_decompressor *decompressor = libdeflate_alloc_decompressor();
+
+    long i = 0;
+    std::vector<GZIP_BLOCK>::iterator block;
+    for (block = param.blocks->begin() + param.start, i = 0; i < param.length;
+         ++block, ++i) {
+        if (block->compressed == NULL)
+            continue;
+        if (block->uncompressed == NULL) {
+            block->uncompressed = new char[block->uncompressed_size];
+            //std::cout << "block id : " << i
+            //          << ", size : " << block->uncompressed_size << std::endl;
+        }
+        size_t actual_in_nbytes = 0;
+        size_t actual_out_nbytes = 0;
+        enum libdeflate_result result;
+        while (block->compressed_size != 0) {
+            result = libdeflate_gzip_decompress_ex(
+                decompressor, block->compressed, block->compressed_size,
+                block->uncompressed, block->uncompressed_size,
+                &actual_in_nbytes,
+                &actual_out_nbytes); // &actual_in_bytes, &actual_out_bytes);
+            if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
+                block->uncompressed_size *= 2;
+                delete[] block->uncompressed;
+                block->uncompressed = new char[block->uncompressed_size];
+                //std::cout << "block id : " << i << ", allocated_buffer_size : "
+                //          << block->uncompressed_size << std::endl;
+                continue;
+            }
+            block->compressed += actual_in_nbytes;
+            block->compressed_size -= actual_in_nbytes;
+            block->actual_out_nbytes += actual_out_nbytes;
+        }
+        *param.total_size += block->actual_out_nbytes;
+        //std::cout << "block id : " << i
+        //          << ", actual_out_nbytes : " << block->actual_out_nbytes
+        //          << std::endl;
+    }
+    libdeflate_free_decompressor(decompressor);
+    return (void *)1;
+}
+
+/**
+ * @brief Thread function to merge decompressed GZIP blocks into a buffer.
+ *
+ * This function is intended to be run as a thread. It processes a range of GZIP blocks,
+ * copying their uncompressed data into a specified buffer at the appropriate offsets.
+ * After copying, it deallocates the memory used by the uncompressed data.
+ *
+ * @param arg Pointer to a MERGE_THREAD_PARAM structure containing the parameters for the thread.
+ * @return Always returns (void *)1.
+ *
+ * The MERGE_THREAD_PARAM structure should contain:
+ * - start: The starting index of the blocks to process.
+ * - end: The ending index of the blocks to process.
+ * - blocks: A pointer to a vector of GZIP_BLOCK structures.
+ * - buffer: A pointer to the buffer where the uncompressed data should be copied.
+ *
+ * Each GZIP_BLOCK structure should contain:
+ * - offset: The offset in the buffer where the uncompressed data should be copied.
+ * - uncompressed: A pointer to the uncompressed data.
+ * - uncompressed_size: The size of the uncompressed data.
+ * - actual_out_nbytes: The actual number of bytes to copy from the uncompressed data.
+ */
+void *merge_thread(void *arg) {
+    MERGE_THREAD_PARAM *param = (MERGE_THREAD_PARAM *)arg;
+    long i = 0;
+    for (i = param->start; i < param->end; ++i) {
+        GZIP_BLOCK *block = &(*param->blocks)[i];
+        if (block->offset < 0)
+            continue;
+        if (block->uncompressed == NULL)
+            continue;
+        if (block->uncompressed_size == 0)
+            continue;
+        //std::copy(block->uncompressed, block->uncompressed + block->actual_out_nbytes,
+         //         param->buffer + block->offset);
+        memcpy(param->buffer + block->offset, block->uncompressed,
+              block->actual_out_nbytes);
+        delete[] block->uncompressed;
+    }
+    return (void *)1;
+}
+
+void *buffer_release_job(void *arg) {
+    char *buffer = (char *)arg;
+    delete[] buffer;
+    return NULL;
+}
+
+/**
+ * @brief Unzips a given FASTQ file using multiple threads.
+ *
+ * This function reads a compressed FASTQ file, identifies GZIP blocks,
+ * and decompresses them using multiple threads. The decompressed data
+ * is then merged into a single buffer.
+ *
+ * @param file_name The name of the compressed FASTQ file.
+ * @param thread_count The number of threads to use for decompression.
+ * @return true if the file was successfully decompressed, false otherwise.
+ */
+bool FastqUnzip::Unzip(const std::string &file_name, int thread_count) {
+    std::ifstream ifile(file_name.c_str(), std::ifstream::binary);
+    ifile.seekg(0, ifile.end);
+    long file_size = ifile.tellg();
+    ifile.seekg(0, ifile.beg);
+
+    unsigned char *compressed_buffer = new unsigned char[file_size];
+    ifile.read((char *const)compressed_buffer,
+               file_size); // 4L*1000*1000*1000);
+    ifile.close();
+
+    std::vector<GZIP_BLOCK> blocks;
+
+    if (find_gzip_members((const char *const)compressed_buffer, file_size,
+                          thread_count, &blocks) == false) {
+        return false;
+    }
+    if (blocks.size() == 1) {
+        blocks[0].uncompressed_size = blocks[0].compressed_size * 6;
+    }
+    int i = 0;
+    long chunk_size = blocks.size() / thread_count;
+    long start_index = 0;
+    std::vector<pthread_t> threads;
+    for (i = 0; i < thread_count; ++i) {
+        THREAD_PARAM *p = new THREAD_PARAM;
+        p->start = start_index;
+        p->length = chunk_size;
+        p->blocks = &blocks;
+        p->total_size = &total_out_size;
+        start_index += chunk_size;
+        if (i < blocks.size() % thread_count) {
+            p->length++;
+            start_index++;
+        }
+
+        if (p->start + p->length > blocks.size())
+            p->length = blocks.size() - p->start;
+
+        pthread_t t;
+        int s = pthread_create(&t, NULL, job_thread, (void *)p);
+        threads.push_back(t);
+    }
+    std::vector<pthread_t>::iterator thread;
+    for (thread = threads.begin(); thread != threads.end(); ++thread) {
+        void *res = NULL;
+        pthread_join(*thread, &res);
+    }
+
+    // release buffer
+    pthread_t buffer_release_thread;
+    pthread_create(&buffer_release_thread, NULL, buffer_release_job,
+                   (void *)compressed_buffer);
+
+    long offset = 0;
+    std::vector<GZIP_BLOCK>::iterator block;
+    for (block = blocks.begin(); block != blocks.end(); ++block) {
+        block->offset = offset;
+        offset += block->actual_out_nbytes;
+    }
+    if (blocks.size() > 1){
+        uncompressed_buffer = new char[total_out_size];
+        std::vector<MERGE_THREAD_PARAM *> merge_params;
+        std::vector<pthread_t> merge_threads;
+        chunk_size = blocks.size() / thread_count;
+        start_index = 0;
+        int end_index =0;
+        for (i = 0; i < thread_count; ++i) {
+            MERGE_THREAD_PARAM *p = new MERGE_THREAD_PARAM;
+            p->buffer = uncompressed_buffer;
+            p->start = end_index;
+            p->end = start_index + chunk_size;
+            end_index = p->end;
+    
+            if (i == thread_count - 1) {
+                p->end = blocks.size();
+            }
+
+            if (p->start + p->end > blocks.size())
+            {
+                p->end = blocks.size() - p->start;
+            }
+
+            if(p->start == p->end)
+                continue;
+
+            p->blocks = &blocks;
+
+            pthread_t t;
+            int s = pthread_create(&t, NULL, merge_thread, (void *)p);
+            if (s != 0) {
+                std::cerr << "thread failed: [ " << block->index << " ]."
+                        << std::endl;
+                continue;
+            }
+            merge_params.push_back(p);
+            merge_threads.push_back(t);
+        }
+
+        for (thread = merge_threads.begin(); thread != merge_threads.end();
+            ++thread) {
+            void *res = NULL;
+            pthread_join(*thread, &res);
+        }
+    }
+    else{
+        uncompressed_buffer = blocks[0].uncompressed;
+    }
+    return true;
+}
+#endif // FASTQSTAT_UNZIP_H_


### PR DESCRIPTION
#1 

## 배경
최신 노드는 메모리와 cpu환경이 좋아졌기에, 하드웨어를 최대한 활용하여 빠르게 fastq stat을 추출하는 모듈이 필요함
ssd disk환경에서는 2분 미만의 수행시간으로 wgs파일의 fastq stat을 추출할 수 있음
아키텍쳐에 관한 내용은 아래 피피티를 참고 부탁드립니다.
[링크](https://docs.google.com/presentation/d/17-QWEmUvT2xBpkigZv_E6-rVC_Ni488lh8DolgASRl8/edit#slide=id.g2fb84d9de41_1_174)

## 개발 관련

- adenine98번 노드에서 개발을 진행했습니다. 

- 2개의 fastq.gz 파일을 메모리에 올린 후 메모리 해제를 진행하기에 많은 메모리를 사용합니다. 

- 메모리 사용량 =  2*fastq.gz + 2*fastq + etc

- quality 계산시 avx명령어를 사용합니다.

